### PR TITLE
fix: update quantity input handling and set default value on blur

### DIFF
--- a/components/micro/Quantity.vue
+++ b/components/micro/Quantity.vue
@@ -1,21 +1,28 @@
 <script setup>
   import {watch} from 'vue' 
+  
   const model = defineModel('model');
   const props = defineProps({
     min:{type:[Number,String],default:0},
     max:{type:[Number,String],default:100}
   })
-  const decreaseQuantity = () =>{
+  const decreaseQuantity = () => {
     model.value--;
   }
-  const increaseQuantity = () =>{
+  const increaseQuantity = () => {
     model.value++;
   }
 
-  watch(model,(newVal,oldVal)=>{
+  const handleBlur = () => {
+    if (!model.value) {
+      model.value = 1;
+    }
+  }
+
+  watch(model, (newVal, oldVal) => {    
     if(newVal < props.min) model.value = props.min
-    else if(newVal > props.max) model.value = props.max
-  })
+      else if(newVal > props.max) model.value = props.max
+    })
 </script>
 
 <template>
@@ -25,7 +32,7 @@
       icon="mdi:minus"
       @clickTrigger="decreaseQuantity"
     />
-    <input v-model="model" :min="min" :max="max" class="quantity-input" type="number">
+    <input v-model="model" :min="min" :max="max" @blur="handleBlur" class="quantity-input" type="number" pattern="[0-9]*" inputmode="numeric"/>
     <Button
       class="buttons"
       icon="mdi:plus"

--- a/generated/version.js
+++ b/generated/version.js
@@ -1,1 +1,1 @@
-export const version='1.0.0'
+export const version='1.1.0'


### PR DESCRIPTION
This pull request updates the `Quantity.vue` component to improve input validation and user experience for the quantity input field. The most important changes include adding a handler to ensure the quantity defaults to 1 when the input is left empty, and enhancing the input field for better numeric input on mobile devices.

**Input validation improvements:**

* Added a `handleBlur` method that sets the quantity to 1 if the input is empty when the field loses focus, preventing invalid or empty values.

**User experience enhancements:**

* Updated the quantity `<input>` element to call `handleBlur` on blur, and set `pattern="[0-9]*"` and `inputmode="numeric"` to improve numeric input support, especially on mobile devices.